### PR TITLE
feat: add support for solid color and gradient backgrounds in builder…

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,24 +244,72 @@
 					});
 				}
 
-				function renderPanels() {
-					panelsEl.innerHTML = "";
-					folders.forEach((f) => {
-						const wrapper = document.createElement("div");
-						wrapper.className = `bg-white/90 dark:bg-slate-800/90 backdrop-blur rounded-2xl border border-slate-200 dark:border-slate-700 shadow-lg overflow-hidden ${f === state.activeFolder ? "" : "hidden"}`;
-						const header = document.createElement("div");
-						header.className = "bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-700 dark:to-slate-600 px-5 py-3 border-b border-slate-200 dark:border-slate-600";
-						header.innerHTML = `<h4 class='font-semibold text-sm md:text-base text-slate-800 dark:text-slate-200 flex items-center gap-2'><span>${emojiMap[f]}</span><span>${f.charAt(0).toUpperCase() + f.slice(1)} Options</span><span class='ml-auto text-xs font-normal text-slate-500 dark:text-slate-400'>${options[f] ? options[f].length + (f !== "body" ? 1 : 0) : 0} choices</span></h4>`;
-						const panel = document.createElement("div");
-						panel.id = `panel-${f}`;
-						panel.setAttribute("role", "tabpanel");
-						panel.className = "thumbs grid gap-6 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 max-h-[20rem] overflow-y-auto p-6";
-						if (f !== "body") panel.appendChild(createThumb({ folder: f, file: null }));
-						if (options[f]) options[f].forEach((file) => panel.appendChild(createThumb({ folder: f, file })));
-						wrapper.append(header, panel);
-						panelsEl.appendChild(wrapper);
-					});
-				}
+				   function renderPanels() {
+					   panelsEl.innerHTML = "";
+					   folders.forEach((f) => {
+						   const wrapper = document.createElement("div");
+						   wrapper.className = `bg-white/90 dark:bg-slate-800/90 backdrop-blur rounded-2xl border border-slate-200 dark:border-slate-700 shadow-lg overflow-hidden ${f === state.activeFolder ? "" : "hidden"}`;
+						   const header = document.createElement("div");
+						   header.className = "bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-700 dark:to-slate-600 px-5 py-3 border-b border-slate-200 dark:border-slate-600";
+						   header.innerHTML = `<h4 class='font-semibold text-sm md:text-base text-slate-800 dark:text-slate-200 flex items-center gap-2'><span>${emojiMap[f]}</span><span>${f.charAt(0).toUpperCase() + f.slice(1)} Options</span><span class='ml-auto text-xs font-normal text-slate-500 dark:text-slate-400'>${options[f] ? options[f].length + (f !== "body" ? 1 : 0) : 0} choices</span></h4>`;
+						   const panel = document.createElement("div");
+						   panel.id = `panel-${f}`;
+						   panel.setAttribute("role", "tabpanel");
+						   panel.className = "thumbs grid gap-6 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 max-h-[20rem] overflow-y-auto p-6";
+						   // Add color/gradient controls only for bg
+						   if (f === "bg") {
+							   // Solid color picker
+							   const colorWrap = document.createElement("div");
+							   colorWrap.className = "col-span-2 flex items-center gap-2 mb-2";
+							   const colorLabel = document.createElement("label");
+							   colorLabel.textContent = "Solid Color:";
+							   colorLabel.className = "text-xs font-medium text-slate-700 dark:text-slate-200";
+							   colorLabel.htmlFor = "bg-color-picker";
+							   const colorInput = document.createElement("input");
+							   colorInput.type = "color";
+							   colorInput.id = "bg-color-picker";
+							   colorInput.value = selections.bg && selections.bg.startsWith("color:") ? selections.bg.slice(6) : "#ffffff";
+							   colorInput.className = "w-8 h-8 border rounded shadow-sm cursor-pointer";
+							   colorInput.addEventListener("input", (e) => {
+								   selections.bg = "color:" + e.target.value;
+								   updateSelectionUI("bg");
+								   draw();
+							   });
+							   colorWrap.appendChild(colorLabel);
+							   colorWrap.appendChild(colorInput);
+							   panel.appendChild(colorWrap);
+							   // Gradient input
+							   const gradWrap = document.createElement("div");
+							   gradWrap.className = "col-span-2 flex items-center gap-2 mb-4";
+							   const gradLabel = document.createElement("label");
+							   gradLabel.textContent = "CSS Gradient:";
+							   gradLabel.className = "text-xs font-medium text-slate-700 dark:text-slate-200";
+							   gradLabel.htmlFor = "bg-gradient-input";
+							   const gradInput = document.createElement("input");
+							   gradInput.type = "text";
+							   gradInput.id = "bg-gradient-input";
+							   gradInput.placeholder = "e.g. linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%)";
+							   gradInput.value = selections.bg && selections.bg.startsWith("gradient:") ? selections.bg.slice(9) : "";
+							   gradInput.className = "flex-1 min-w-0 border rounded px-2 py-1 text-xs shadow-sm bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-100";
+							   gradInput.addEventListener("change", (e) => {
+								   if (e.target.value.trim()) {
+									   selections.bg = "gradient:" + e.target.value.trim();
+								   } else if (selections.bg && selections.bg.startsWith("gradient:")) {
+									   selections.bg = null;
+								   }
+								   updateSelectionUI("bg");
+								   draw();
+							   });
+							   gradWrap.appendChild(gradLabel);
+							   gradWrap.appendChild(gradInput);
+							   panel.appendChild(gradWrap);
+						   }
+						   if (f !== "body") panel.appendChild(createThumb({ folder: f, file: null }));
+						   if (options[f]) options[f].forEach((file) => panel.appendChild(createThumb({ folder: f, file })));
+						   wrapper.append(header, panel);
+						   panelsEl.appendChild(wrapper);
+					   });
+				   }
 
 				function createThumb({ folder, file }) {
 					const tile = document.createElement("button");
@@ -331,16 +379,91 @@
 					});
 				}
 
-				function draw() {
-					ctx.clearRect(0, 0, canvas.width, canvas.height);
-					(async () => {
-						for (const folder of folders) {
-							const file = selections[folder];
-							if (!file) continue;
-							await loadAndDraw(`assets/${folder}/${file}`);
-						}
-					})();
-				}
+				   function draw() {
+					   ctx.clearRect(0, 0, canvas.width, canvas.height);
+					   // Draw color or gradient background if selected
+					   if (selections.bg) {
+						   if (typeof selections.bg === "string" && selections.bg.startsWith("color:")) {
+							   ctx.save();
+							   ctx.fillStyle = selections.bg.slice(6);
+							   ctx.fillRect(0, 0, canvas.width, canvas.height);
+							   ctx.restore();
+						   } else if (typeof selections.bg === "string" && selections.bg.startsWith("gradient:")) {
+							   // Try to parse CSS gradient string
+							   try {
+								   // Create a temporary element to get the gradient
+								   const gradStr = selections.bg.slice(9);
+								   // Only support linear-gradient and radial-gradient for canvas
+								   let grad;
+								   if (gradStr.startsWith("linear-gradient")) {
+									   // Parse angle and color stops
+									   // Example: linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%)
+									   const match = gradStr.match(/linear-gradient\(([^,]+),(.+)\)/);
+									   if (match) {
+										   let angle = match[1].trim();
+										   let stops = match[2].split(",").map(s => s.trim());
+										   // Convert angle to radians
+										   let theta = 0;
+										   if (angle.endsWith("deg")) {
+											   theta = (parseFloat(angle) - 90) * Math.PI / 180;
+										   }
+										   // Calculate x0,y0,x1,y1 for the angle
+										   const r = Math.SQRT2 * 0.5 * canvas.width;
+										   const cx = canvas.width / 2, cy = canvas.height / 2;
+										   const x0 = cx - r * Math.cos(theta);
+										   const y0 = cy - r * Math.sin(theta);
+										   const x1 = cx + r * Math.cos(theta);
+										   const y1 = cy + r * Math.sin(theta);
+										   grad = ctx.createLinearGradient(x0, y0, x1, y1);
+										   stops.forEach(stop => {
+											   const parts = stop.match(/(#[0-9a-fA-F]{3,8}|rgba?\([^\)]+\)|[a-zA-Z]+)\s*(\d+%?)?/);
+											   if (parts) {
+												   grad.addColorStop(parts[2] ? parseFloat(parts[2]) / 100 : undefined, parts[1]);
+											   }
+										   });
+									   }
+								   } else if (gradStr.startsWith("radial-gradient")) {
+									   // Only basic radial gradient: radial-gradient(circle, #fff 0%, #000 100%)
+									   const match = gradStr.match(/radial-gradient\(([^,]+),(.+)\)/);
+									   if (match) {
+										   let stops = match[2].split(",").map(s => s.trim());
+										   grad = ctx.createRadialGradient(
+											   canvas.width/2, canvas.height/2, 0,
+											   canvas.width/2, canvas.height/2, canvas.width/2
+										   );
+										   stops.forEach(stop => {
+											   const parts = stop.match(/(#[0-9a-fA-F]{3,8}|rgba?\([^\)]+\)|[a-zA-Z]+)\s*(\d+%?)?/);
+											   if (parts) {
+												   grad.addColorStop(parts[2] ? parseFloat(parts[2]) / 100 : undefined, parts[1]);
+											   }
+										   });
+									   }
+								   }
+								   if (grad) {
+									   ctx.save();
+									   ctx.fillStyle = grad;
+									   ctx.fillRect(0, 0, canvas.width, canvas.height);
+									   ctx.restore();
+								   }
+							   } catch (e) {
+								   // Fallback: do nothing
+							   }
+						   } else if (selections.bg) {
+							   // Fallback to image if not color/gradient
+							   if (options.bg && options.bg.includes(selections.bg)) {
+								   loadAndDraw(`assets/bg/${selections.bg}`);
+							   }
+						   }
+					   }
+					   (async () => {
+						   for (const folder of folders) {
+							   if (folder === "bg") continue; // already drawn
+							   const file = selections[folder];
+							   if (!file) continue;
+							   await loadAndDraw(`assets/${folder}/${file}`);
+						   }
+					   })();
+				   }
 
 				function loadAndDraw(src) {
 					return new Promise((resolve, reject) => {
@@ -358,24 +481,52 @@
 					return arr[Math.floor(Math.random() * arr.length)];
 				}
 
-				randomizeBtn.addEventListener("click", () => {
-					folders.forEach((f) => {
-						if (f === "body") {
-							selections[f] = randomChoice(options[f]);
-						} else {
-							const opts = [null, ...options[f]];
-							selections[f] = randomChoice(opts);
-						}
-						updateSelectionUI(f);
-					});
-					draw();
-				});
 
-				clearBtn.addEventListener("click", () => {
-					folders.forEach((f) => (selections[f] = f === "body" ? options[f][0] : null));
-					folders.forEach(updateSelectionUI);
-					draw();
-				});
+				   function randomColor() {
+					   // Generate a random hex color
+					   return '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+				   }
+				   function randomGradient() {
+					   // Generate a simple random linear gradient
+					   const c1 = randomColor();
+					   const c2 = randomColor();
+					   const angle = Math.floor(Math.random()*360);
+					   return `linear-gradient(${angle}deg, ${c1} 0%, ${c2} 100%)`;
+				   }
+
+				   randomizeBtn.addEventListener("click", () => {
+					   folders.forEach((f) => {
+						   if (f === "body") {
+							   selections[f] = randomChoice(options[f]);
+						   } else if (f === "bg") {
+							   // Randomly pick color, gradient, image, or none
+							   const bgTypes = [
+								   () => null,
+								   () => "color:" + randomColor(),
+								   () => "gradient:" + randomGradient(),
+								   () => randomChoice(options.bg)
+							   ];
+							   selections.bg = bgTypes[Math.floor(Math.random()*bgTypes.length)]();
+						   } else {
+							   const opts = [null, ...options[f]];
+							   selections[f] = randomChoice(opts);
+						   }
+						   updateSelectionUI(f);
+					   });
+					   draw();
+				   });
+
+				   clearBtn.addEventListener("click", () => {
+					   folders.forEach((f) => {
+						   if (f === "body") {
+							   selections[f] = options[f][0];
+						   } else {
+							   selections[f] = null;
+						   }
+					   });
+					   folders.forEach(updateSelectionUI);
+					   draw();
+				   });
 
 				downloadBtn.addEventListener("click", () => {
 					const a = document.createElement("a");


### PR DESCRIPTION
This pull request adds the ability to set a solid color or CSS gradient as the background in the Clippy PFP Generator.

Features:

Users can now pick a solid color using a color picker or enter a CSS gradient in the background panel.
The canvas rendering logic supports both color and gradient backgrounds, in addition to image backgrounds.
Randomize and reset actions now include these new background types.