### PR TITLE
Fix UI style consistency across generator and article pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,18 +54,19 @@
 	</head>
 	<body class="min-h-screen bg-gradient-to-br from-sky-100/80 via-white to-cyan-100/80 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 text-slate-800 dark:text-slate-200 font-sans antialiased selection:bg-sky-600/70 selection:text-white">
 		<header class="sticky top-0 z-40 bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-slate-200 dark:border-slate-800 shadow-sm">
-			<div class="max-w-4xl mx-auto px-4 py-3 flex items-center gap-4">
-				<div class="flex items-center gap-2 font-bold text-xl tracking-tight">
+			<div class="max-w-4xl mx-auto px-2 sm:px-6 md:px-10 py-3 flex items-center gap-4">
+				<a href="./index.html" class="flex items-center gap-2 font-bold text-lg tracking-tight text-slate-800 dark:text-slate-100">
 					<span class="text-sky-500">📎</span>
 					<span>Clippy PFP Generator</span>
-				</div>
-				<div class="ml-auto flex items-center gap-2">
-					<button id="themeToggle" class="rounded-lg px-3 py-1.5 text-base font-medium bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" aria-label="Toggle dark mode">🌙</button>
-				</div>
+				</a>
+				<nav class="ml-auto flex items-center gap-3 text-sm">
+					<a href="./Why-Is-Everyone-Changing-Their-Profile-Picture-to-Clippy.html" class="px-3 py-1.5 rounded-md bg-sky-600 text-white hover:bg-sky-500 font-medium">Article</a>
+					<button id="themeToggle" class="ml-1 rounded-md px-3 py-1.5 text-sm font-medium bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" aria-label="Toggle dark mode">🌙</button>
+				</nav>
 			</div>
 		</header>
 
-		<main class="max-w-6xl mx-auto px-4 py-8 flex flex-col gap-8">
+		<main class="max-w-6xl mx-auto px-2 sm:px-6 md:px-10 py-8 flex flex-col gap-8">
 			<!-- Hero -->
 			<section class="text-center max-w-3xl mx-auto flex flex-col gap-6">
 				<div class="flex items-end justify-center gap-4 mb-2">
@@ -83,9 +84,9 @@
 				<div class="xl:col-span-1 flex flex-col gap-6">
 					<div class="relative group">
 						<div class="absolute -inset-2 rounded-3xl bg-gradient-to-br from-sky-400/30 via-cyan-300/30 to-sky-500/30 blur-xl opacity-0 group-hover:opacity-100 transition-all duration-500"></div>
-						<div class="relative rounded-3xl bg-white/95 dark:bg-slate-800/95 shadow-2xl border border-slate-200/50 dark:border-slate-700/50 overflow-hidden">
+						<div class="relative rounded-3xl bg-white/95 dark:bg-slate-900/95 shadow-2xl border border-sky-100/60 dark:border-slate-800 overflow-hidden">
 							<!-- Canvas Header -->
-							<div class="bg-gradient-to-r from-sky-50 to-cyan-50 dark:from-slate-800 dark:to-slate-700 px-6 py-4 border-b border-slate-200 dark:border-slate-700">
+							<div class="bg-gradient-to-r from-sky-50 to-cyan-50 dark:from-slate-800 dark:to-slate-700 px-6 py-4 border-b border-sky-100 dark:border-slate-700">
 								<h3 class="font-bold text-lg text-slate-800 dark:text-slate-200 flex items-center gap-2">
 									<span class="w-2 h-2 bg-green-500 rounded-full"></span>
 									Live Preview
@@ -96,9 +97,9 @@
 							<div class="p-6 sm:p-8 flex flex-col items-center gap-6">
 								<canvas id="preview" width="512" height="512" class="w-full max-w-[16rem] sm:max-w-[20rem] md:max-w-[22rem] aspect-square rounded-2xl ring-4 ring-sky-100 dark:ring-sky-900 bg-[repeating-conic-gradient(theme(colors.slate.200)_0%_25%,theme(colors.slate.50)_0%_50%)] [background-size:24px_24px] shadow-lg hover:shadow-2xl transition-shadow duration-300"></canvas>
 								<div class="flex flex-wrap justify-center gap-3 w-full">
-									<button id="randomize" class="group inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold bg-gradient-to-r from-sky-600 to-sky-500 text-white hover:from-sky-500 hover:to-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200"><span>🎲</span><span>Randomize</span></button>
-									<button id="clear" class="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold bg-slate-100 text-slate-800 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200">🗑️ <span>Reset</span></button>
-									<button id="download" class="group inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold bg-gradient-to-r from-sky-600 to-sky-500 text-white hover:from-sky-500 hover:to-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200"><span>⬇️</span><span>Download</span></button>
+									<button id="randomize" class="group inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-bold bg-gradient-to-r from-sky-600 to-sky-500 text-white hover:from-sky-500 hover:to-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200"><span>🎲</span><span>Randomize</span></button>
+									<button id="clear" class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold bg-slate-100 text-slate-800 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200">🗑️ <span>Reset</span></button>
+									<button id="download" class="group inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-bold bg-gradient-to-r from-sky-600 to-sky-500 text-white hover:from-sky-500 hover:to-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200"><span>⬇️</span><span>Download</span></button>
 								</div>
 							</div>
 						</div>
@@ -110,7 +111,7 @@
 				<!-- Builder Controls -->
 				<div class="xl:col-span-2 flex flex-col gap-6">
 					<!-- Category Tabs -->
-					<div class="bg-white/80 dark:bg-slate-800/80 backdrop-blur rounded-2xl border border-slate-200 dark:border-slate-700 p-6 shadow-lg">
+					<div class="bg-white/95 dark:bg-slate-900/95 rounded-2xl border border-sky-100/60 dark:border-slate-800 p-6 shadow-lg">
 						<h3 class="font-bold text-xl text-slate-800 dark:text-slate-200 mb-4 flex items-center gap-2">🎨 Customize Parts</h3>
 						<nav id="tabs" class="flex flex-wrap gap-3" aria-label="Asset categories"></nav>
 					</div>
@@ -213,15 +214,15 @@
 
 				// ---------- UI helper class builders ----------
 				function tabClass(folder, active) {
-					const base = "group inline-flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-xs md:text-sm font-semibold tracking-wide transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400";
-					if (active) return base + " bg-sky-600 text-white shadow-sm ring-1 ring-sky-500 scale-[1.05]";
-					return base + " bg-slate-100/80 dark:bg-slate-700/70 text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600 hover:shadow";
+					const base = "group inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs md:text-sm font-semibold tracking-wide transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400";
+					if (active) return base + " bg-sky-600 text-white shadow-sm ring-1 ring-sky-500 scale-[1.03]";
+					return base + " bg-slate-100/90 dark:bg-slate-800/90 text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700 hover:shadow-sm";
 				}
 
 				function thumbClass(folder, selected) {
-					const base = `thumb-tile group relative aspect-square flex items-center justify-center rounded-xl border-2 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400`;
-					if (selected) return base + " border-sky-500 dark:border-sky-400 bg-sky-50 dark:bg-sky-900/20 ring-4 ring-sky-200 dark:ring-sky-800 shadow-xl scale-105";
-					return base + " border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/60 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-lg hover:scale-105";
+					const base = `thumb-tile group relative aspect-square flex items-center justify-center rounded-lg border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400`;
+					if (selected) return base + " border-sky-100/80 dark:border-sky-400 bg-sky-50 dark:bg-sky-900/10 ring-2 ring-sky-200 dark:ring-sky-800 shadow-md scale-102";
+					return base + " border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/60 hover:border-sky-200 dark:hover:border-sky-600 hover:shadow-sm hover:scale-105";
 				}
 
 				function renderTabs() {
@@ -247,10 +248,10 @@
 				   function renderPanels() {
 					   panelsEl.innerHTML = "";
 					   folders.forEach((f) => {
-						   const wrapper = document.createElement("div");
-						   wrapper.className = `bg-white/90 dark:bg-slate-800/90 backdrop-blur rounded-2xl border border-slate-200 dark:border-slate-700 shadow-lg overflow-hidden ${f === state.activeFolder ? "" : "hidden"}`;
-						   const header = document.createElement("div");
-						   header.className = "bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-700 dark:to-slate-600 px-5 py-3 border-b border-slate-200 dark:border-slate-600";
+						const wrapper = document.createElement("div");
+						wrapper.className = `bg-white/95 dark:bg-slate-900/95 rounded-2xl border border-sky-100/60 dark:border-slate-800 shadow overflow-hidden ${f === state.activeFolder ? "" : "hidden"}`;
+						const header = document.createElement("div");
+						header.className = "bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-800 dark:to-slate-700 px-5 py-3 border-b border-sky-100 dark:border-slate-700";
 						   header.innerHTML = `<h4 class='font-semibold text-sm md:text-base text-slate-800 dark:text-slate-200 flex items-center gap-2'><span>${emojiMap[f]}</span><span>${f.charAt(0).toUpperCase() + f.slice(1)} Options</span><span class='ml-auto text-xs font-normal text-slate-500 dark:text-slate-400'>${options[f] ? options[f].length + (f !== "body" ? 1 : 0) : 0} choices</span></h4>`;
 						   const panel = document.createElement("div");
 						   panel.id = `panel-${f}`;


### PR DESCRIPTION
## Problem

The generator page had inconsistent styling compared to the article page. Different padding, card backgrounds, borders, button sizes, and color tokens made the two pages feel disconnected.

## Solution

Updated `index.html` to use the same visual design tokens as the article page:

### Header
- Changed padding to match article's responsive system (`px-2 sm:px-6 md:px-10`)
- Added article navigation link for easier navigation between pages
- Resized theme toggle button to match article page styling

### Cards & Surfaces
- Updated all card backgrounds from `slate-800/80-90` to `slate-900/95` in dark mode
- Changed borders from mixed `slate-200/300` to consistent `sky-100/60` tokens
- Applied same card opacity and blur effects across preview, tabs, and panel containers

### Buttons & Controls
- Reduced button rounding from `rounded-xl` to `rounded-lg` for consistency
- Adjusted padding from `px-5 py-2.5` to `px-4 py-2` to match article buttons
- Updated tab button styling to use same background opacity and hover states

### Thumbnails & Tiles
- Changed border weight from `border-2` to `border` for cleaner look
- Updated border colors to match the site's color system
- Adjusted selected/hover states to use consistent sky tones

### JavaScript Helpers
- Modified `tabClass()` and `thumbClass()` functions to return updated class strings
- Kept all existing behavior intact—only visual changes

## Testing

Verified by loading both pages side-by-side and comparing:
- Header layout and spacing
- Card surface treatment
- Button styling
- Color consistency in light and dark modes

All functionality remains unchanged—randomize, download, keyboard shortcuts, and canvas compositing work exactly as before.

Fixes #13